### PR TITLE
A few small fixes

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -37,7 +37,7 @@ h3 {
     font-weight: 900;
     font-size: 2.5rem;
     line-height: 1.25;
-    margin-top: 0.7rem;
+    margin-top: 0;
 
     &::after {
         display: block;

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -316,6 +316,10 @@ span.type {
     flex: 1;
 }
 
+.gist {
+    margin-left: 37.5%;
+}
+
 .background {
     background-color: $color-primary;
 

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -627,6 +627,14 @@ span.type {
 
         .content {
             flex: 5;
+
+            p:first-of-type {
+                margin-top: 0;
+            }
+
+            p:last-of-type {
+                margin-bottom: 0;
+            }
         }
     }
 

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -257,6 +257,10 @@ header {
         flex-direction: column;
         vertical-align: bottom;
 
+        p {
+            padding-top: 1rem;
+        }
+
         &.underscore::before {
             content: "_";
             font-size: 7rem;
@@ -302,6 +306,10 @@ span.type {
     &::after {
         content: " PROJECT";
     }
+}
+
+.block {
+    display: block;
 }
 
 .spacer {

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -589,7 +589,7 @@ span.type {
     }
 
     .intro, blockquote {
-        font-size: 2.571428rem;
+        font-size: 2rem;
         line-height: 1.666;
         color: $color-primary;
     }
@@ -615,7 +615,7 @@ span.type {
 
     section {
         display: flex;
-        margin: 2rem 0;
+        margin: 4rem 0;
 
         h3 {
             flex: 2;
@@ -628,41 +628,49 @@ span.type {
 
     .mediathek-embed {
         margin: 8rem 0;
-        position: relative;
 
-        img {
-            display: block;
-            width: 100%;
-            height: auto;
-        }
+        .mediathek-player {
+            position: relative;
 
-        iframe {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
+            img {
+                display: block;
+                width: 100%;
+                height: auto;
+            }
+
+            iframe {
+                position: absolute;
+                top: 0;
+                left: 0;
+                width: 100%;
+                height: 100%;
+            }
         }
     }
 
     figure {
         margin: 8rem 0;
 
-        img {
-            display: block;
-            margin: 0 auto;
-        }
-
-        blockquote {
-            font-style: italic;
-            margin: 0 1/8*100% 0 2/8*100%;
-        }
-
         figcaption {
             font-size: 1.15rem;
             color: $color-primary;
             text-align: right;
             text-transform: uppercase;
+        }
+
+        img {
+            display: block;
+            margin: 0 auto;
+
+            & + figcaption {
+                margin-left: 3/8*100%;
+                text-align: left;
+            }
+        }
+
+        blockquote {
+            font-style: italic;
+            margin: 0 1/8*100% 0 2/8*100%;
         }
     }
 }

--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -519,10 +519,10 @@ span.type {
         height: auto;
         align-self: center;
         margin-left: 1/8*100%;
-        filter: drop-shadow(10px 10px 0 $color-dark);
+        box-shadow: 10px 10px $color-dark;
     }
 
-    &:nth-child(4n) {
+    &:nth-of-type(even) {
         flex-direction: row-reverse;
 
         img {

--- a/layouts/_default/contact.html
+++ b/layouts/_default/contact.html
@@ -2,7 +2,7 @@
     <header>
         <h1>
             {{ .Title }}
-            <span class="underscore-spacer">_</span>
+            <span class="underscore-spacer"> </span>
         </h1>
         <section class="underscore">
             <div class="spacer"></div>

--- a/layouts/_default/dates.html
+++ b/layouts/_default/dates.html
@@ -2,7 +2,7 @@
     <header>
         <h1>
             {{ .Title }}
-            <span class="underscore-spacer">_</span>
+            <span class="underscore-spacer"> </span>
         </h1>
         <section class="underscore">
             <div class="spacer"></div>

--- a/layouts/_default/project.html
+++ b/layouts/_default/project.html
@@ -2,20 +2,24 @@
     <div class="background {{ .Type | lower }}">
         <header class="project-header">
             <h1>
-                <span class="type">{{ .Type }}</span>
+                <span class="type">{{ .Params.project_id }} {{ .Type }}</span>
                 {{ .CurrentSection.Title }}
                 <span class="underscore-spacer"> </span>
             </h1>
             <section style="text-align: right;">
                 <div class="spacer"></div>
-                <h4>Team</h4>
-                <ul>
-                    {{ range .CurrentSection.Params.team }}
-                        <li>{{ . }}</li>
-                    {{ end }}
-                </ul>
-                <h4>Supervision</h4>
-                {{ .CurrentSection.Params.supervisor }}
+                {{ if .CurrentSection.Params.team }}
+                    <h4>Team</h4>
+                    <ul>
+                        {{ range .CurrentSection.Params.team }}
+                            <li>{{ . }}</li>
+                        {{ end }}
+                    </ul>
+                {{ end }}
+                {{ if .CurrentSection.Params.supervisor }}
+                    <h4>Supervision</h4>
+                    {{ .CurrentSection.Params.supervisor }}
+                {{ end }}
             </section>
         </header>
     </div>

--- a/layouts/_default/projects_archive.html
+++ b/layouts/_default/projects_archive.html
@@ -2,7 +2,7 @@
     <header>
         <h1>
             Archive
-            {{ partial "semester" (dict "type" "short" "semester" .Title) }}
+            <span class="light block">{{ partial "semester" (dict "type" "short" "semester" .Title) }}</span>
             <span class="underscore-spacer"> </span>
         </h1>
         <section class="underscore">

--- a/layouts/_default/projects_archive.html
+++ b/layouts/_default/projects_archive.html
@@ -22,7 +22,7 @@
         {{ range sort $semester_pages "Title" }}
             <section class="projects-list-entry">
                 <div>
-                    <span class="type">{{ .Type }}</span>
+                    <span class="type">{{ .Params.project_id }} {{ .Type }}</span>
                     <h3>{{ .Title }}</h3>
                     <p>{{ .Params.card_description }}</p>
                     <a href="{{ .RelPermalink }}">-> Details</a>

--- a/layouts/_default/projects_list.html
+++ b/layouts/_default/projects_list.html
@@ -2,7 +2,7 @@
     <header>
         <h1>
             {{ .Title }}
-            {{ partial "semester" (dict "type" "short" "semester" .Site.Params.current_semester) }}
+            <span class="light block">{{ partial "semester" (dict "type" "short" "semester" .Site.Params.current_semester) }}</span>
             <span class="underscore-spacer"> </span>
         </h1>
         <section class="underscore">

--- a/layouts/_default/projects_list.html
+++ b/layouts/_default/projects_list.html
@@ -15,7 +15,7 @@
         {{ range sort (where (where $current_semester "Kind" "section") "Type" "!=" .Site.Params.current_semester) "Title" }}
             <section class="projects-list-entry">
                 <div>
-                    <span class="type">{{ .Type }}</span>
+                    <span class="type">{{ .Params.project_id }} {{ .Type }}</span>
                     <h3>{{ .Title }}</h3>
                     <p>{{ .Params.card_description }}</p>
                     <a href="{{ .RelPermalink }}">-> Details</a>

--- a/layouts/_default/schedule.html
+++ b/layouts/_default/schedule.html
@@ -2,7 +2,7 @@
 <header>
     <h1>
         {{ .Title }}
-        {{ partial "semester" (dict "type" "short" "semester" .Site.Params.current_semester) }}
+        <span class="light block">{{ partial "semester" (dict "type" "short" "semester" .Site.Params.current_semester) }}</span>
         <span class="underscore-spacer"> </span>
     </h1>
     <section class="underscore">

--- a/layouts/_default/schedule.html
+++ b/layouts/_default/schedule.html
@@ -1,8 +1,9 @@
 {{ define "main" }}
 <header>
     <h1>
-        {{ .Title }} <br>
-        <span class="underscore-spacer">_</span>
+        {{ .Title }}
+        {{ partial "semester" (dict "type" "short" "semester" .Site.Params.current_semester) }}
+        <span class="underscore-spacer"> </span>
     </h1>
     <section class="underscore">
         <div class="spacer"></div>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -6,11 +6,11 @@
         <li><a href="/dates">Dates</a></li>
         {{ $previous_semester_type := "" }}
         {{ $previous_semester_year := "" }}
-        {{ if eq (slicestr .Site.Params.current_semester 0 2) "ws" }}
-            {{ $previous_semester_type = "ss" }}
+        {{ if eq (slicestr .Site.Params.current_semester 0 2) "ss" }}
+            {{ $previous_semester_type = "ws" }}
             {{ $previous_semester_year = slicestr .Site.Params.current_semester 2 }}
         {{ else }}
-            {{ $previous_semester_type = "ws" }}
+            {{ $previous_semester_type = "ss" }}
             {{ $previous_semester_year = sub (int (slicestr .Site.Params.current_semester 2)) 1 }}
         {{ end }}
         <li><a href="/{{ $previous_semester_type }}{{ $previous_semester_year }}">Archive</a></li>

--- a/layouts/shortcodes/mediathek.html
+++ b/layouts/shortcodes/mediathek.html
@@ -1,11 +1,18 @@
 {{ $video := newScratch }}
 {{ if .IsNamedParams }}
     {{ $video.Set "id" (.Get "id") }}
+    {{ $video.Set "title" (.Get "title") }}
 {{ else }}
     {{ $video.Set "id" (.Get 0) }}
+    {{ $video.Set "title" (.Get 1) }}
 {{ end }}
 
 <div class="mediathek-embed">
-    <img src="/img/16x9.png" alt="video placeholder">
-    <iframe src="https://mediathek.htw-berlin.de/media/embed?key={{ $video.Get "id" }}&responsive=true&autoplay=false&t=0" frameborder="0" allowfullscreen="allowfullscreen" allowtransparency="true" scrolling="no"></iframe>
+    {{ with $video.Get "title" }}
+        <h3>{{ . }}</h3>
+    {{ end }}
+    <div class="mediathek-player">
+        <img src="/img/16x9.png" alt="video placeholder">
+        <iframe src="https://mediathek.htw-berlin.de/media/embed?key={{ $video.Get "id" }}&responsive=true&autoplay=false&t=0" frameborder="0" allowfullscreen="allowfullscreen" allowtransparency="true" scrolling="no"></iframe>
+    </div>
 </div>


### PR DESCRIPTION
Fixed alternating projects list, fixed shadows for project images in Safari
Made semester in schedule title dynamic
Split headers into two lines (regular + light)
Removed margin-top for h3
Fixed projects page issues:  
- video player title
- intro text size
- text block margins
- image captions